### PR TITLE
Untested: Restrict third party devices to iOS

### DIFF
--- a/novid-sdk/src/main/java/org/novid20/sdk/ble/BleClientManager.kt
+++ b/novid-sdk/src/main/java/org/novid20/sdk/ble/BleClientManager.kt
@@ -215,6 +215,7 @@ internal class BleBluetoothManager(
 
             val rssi = result?.rssi
             val bytes = scanRecord?.bytes
+            val appleMsd = scanRecord?.getManufacturerSpecificData(0x004C)
 
             Logger.verbose(TAG, "BLE Result: $deviceName rssi:$rssi address:$deviceAddress ${bytes?.joinToString()}")
 
@@ -263,7 +264,10 @@ internal class BleBluetoothManager(
                 deviceName.let { repo.contactDetected(it, source = TECHNOLOGY_BLE_NAME, rssi = rssi) }
             } else {
                 val isInCache = deviceAddress?.let { deviceMap.contains(it) ?: false }
-                if (isInCache == false) {
+                
+                // Only connect to third party device if the device has a manufacturer data entry
+                // from Apple in order to detect background iOS devices.
+                if (isInCache == false && appleMsd != null) {
                     // Well.. lets potentially connect to third party devices,
                     // but maybe its our iOS device in background without cache
                     // thanks to "donothingloop"


### PR DESCRIPTION
The current behavior of connecting to every third party device may lead to a high battery usage and also cause some issues with bluetooth headsets that do not allow the user to pair anymore if a device is connected via BLE to them.

My proposal here would be to check the manufacturer specific data for an entry from Apple to restrict the scanning to iOS devices and therefore limit the issues with other BLE devices.

Please note that this code is untested :)

![Screenshot_20200408-091010](https://user-images.githubusercontent.com/10475440/78755210-134c6980-7979-11ea-9961-9dc3c156e292.png)
