### PR TITLE
fixed race condition

### DIFF
--- a/novid-sdk/src/main/java/org/novid20/sdk/NovidSdkImpl.kt
+++ b/novid-sdk/src/main/java/org/novid20/sdk/NovidSdkImpl.kt
@@ -204,6 +204,7 @@ internal class NovidSdkImpl internal constructor(
         if (serviceRunning && !detectionRunning) {
             Logger.debug(TAG, "startDetection")
             analytics.sendEvent(EVENT_DETECTION_ON)
+            turnDetectionOffHandler.cancelTimer()
 
             val bluetoothFilter = IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED)
             context.registerReceiver(bluetoothChangeReceiver, bluetoothFilter)

--- a/novid-sdk/src/main/java/org/novid20/sdk/core/CountdownThreadHandler.kt
+++ b/novid-sdk/src/main/java/org/novid20/sdk/core/CountdownThreadHandler.kt
@@ -31,7 +31,9 @@ internal open class CountdownThreadHandler(val runnable: Runnable) {
             override fun run() {
                 try {
                     sleep(countdownTime)
-                    runnable.run()
+                    synchronized(runnable){
+                        runnable.run()
+                    }
                 } catch (iox: InterruptedException) {
                     currentThread().interrupt()
                 }
@@ -41,6 +43,12 @@ internal open class CountdownThreadHandler(val runnable: Runnable) {
         lastStart = current
         lastDuration = duration
         CountdownThread@ this.thread = thread
+    }
+
+    fun cancelTimer(){
+        synchronized(runnable){
+            interrupt()
+        }
     }
 
     private fun interrupt() {


### PR DESCRIPTION
As discussed in Issue https://github.com/novid20org/novid20-android-sdk/issues/6 , cancelling timer during `startDetection` will help avoid race condintion.
`synchronized` is used to avoid case, when runnable is already running to stop detection and we interrupt it with cancel - that could mess up current application state.